### PR TITLE
Cleanup tests

### DIFF
--- a/lib/statistics.ex
+++ b/lib/statistics.ex
@@ -36,9 +36,9 @@ defmodule Ecto.OLAP.Statistics do
         iex>
         iex> alias Ecto.Integration.TestRepo
         iex>
-        iex> TestRepo.all from e in "stats_agg",
+        iex> TestRepo.one from e in "stats_agg",
         ...>   select: corr(e.divorce_rate, e.marg_cons)
-        [0.9806576205544681]
+        0.9806576205544681
     """,
     regr_avgx: """
     Average of the independent variable `x`.
@@ -50,9 +50,9 @@ defmodule Ecto.OLAP.Statistics do
         iex>
         iex> alias Ecto.Integration.TestRepo
         iex>
-        iex> TestRepo.all from e in "stats_agg",
+        iex> TestRepo.one from e in "stats_agg",
         ...>   select: regr_avgx(e.divorce_rate, e.marg_cons)
-        [5.320000000000001]
+        5.320000000000001
     """,
     regr_avgy: """
     Average of the dependent variable `y`.
@@ -64,9 +64,9 @@ defmodule Ecto.OLAP.Statistics do
         iex>
         iex> alias Ecto.Integration.TestRepo
         iex>
-        iex> TestRepo.all from e in "stats_agg",
+        iex> TestRepo.one from e in "stats_agg",
         ...>   select: regr_avgy(e.divorce_rate, e.marg_cons)
-        [4.390000000000001]
+        4.390000000000001
     """,
     regr_count: "Count rows where both expressions are nonnull.",
     regr_r2: """
@@ -79,9 +79,9 @@ defmodule Ecto.OLAP.Statistics do
         iex>
         iex> alias Ecto.Integration.TestRepo
         iex>
-        iex> TestRepo.all from e in "stats_agg",
+        iex> TestRepo.one from e in "stats_agg",
         ...>   select: regr_r2(e.divorce_rate, e.marg_cons)
-        [0.9616893687515513]
+        0.9616893687515513
     """,
     regr_intercept: """
     y-intercept of the least-squares-fit linear equation determined
@@ -94,9 +94,9 @@ defmodule Ecto.OLAP.Statistics do
         iex>
         iex> alias Ecto.Integration.TestRepo
         iex>
-        iex> TestRepo.all from e in "stats_agg",
+        iex> TestRepo.one from e in "stats_agg",
         ...>   select: regr_intercept(e.divorce_rate, e.marg_cons)
-        [3.363198179561455]
+        3.363198179561455
     """,
     regr_slope: """
     Slope of the least-squares-fit linear equation determined
@@ -109,9 +109,9 @@ defmodule Ecto.OLAP.Statistics do
         iex>
         iex> alias Ecto.Integration.TestRepo
         iex>
-        iex> TestRepo.all from e in "stats_agg",
+        iex> TestRepo.one from e in "stats_agg",
         ...>   select: regr_slope(e.divorce_rate, e.marg_cons)
-        [0.1930078609846896]
+        0.1930078609846896
     """,
     regr_sxx: """
     "Sum of squares" of independent variable.
@@ -127,9 +127,9 @@ defmodule Ecto.OLAP.Statistics do
         iex>
         iex> alias Ecto.Integration.TestRepo
         iex>
-        iex> TestRepo.all from e in "stats_agg",
+        iex> TestRepo.one from e in "stats_agg",
         ...>   select: regr_sxx(e.divorce_rate, e.marg_cons)
-        [19.33599999999983]
+        19.33599999999983
     """,
     regr_sxy: """
     "Sum of products" of independent times dependent variable.
@@ -145,9 +145,9 @@ defmodule Ecto.OLAP.Statistics do
         iex>
         iex> alias Ecto.Integration.TestRepo
         iex>
-        iex> TestRepo.all from e in "stats_agg",
+        iex> TestRepo.one from e in "stats_agg",
         ...>   select: regr_sxy(e.divorce_rate, e.marg_cons)
-        [3.7319999999999256]
+        3.7319999999999256
     """,
     regr_syy: """
     "Sum of squares" of dependent variable.
@@ -163,9 +163,9 @@ defmodule Ecto.OLAP.Statistics do
         iex>
         iex> alias Ecto.Integration.TestRepo
         iex>
-        iex> TestRepo.all from e in "stats_agg",
+        iex> TestRepo.one from e in "stats_agg",
         ...>   select: regr_syy(e.divorce_rate, e.marg_cons)
-        [0.7489999999999327]
+        0.7489999999999327
     """,
   ]
 

--- a/test/grouping_sets_test.exs
+++ b/test/grouping_sets_test.exs
@@ -6,18 +6,18 @@ defmodule Ecto.OLAP.GroupingSetsTest do
 
   alias Ecto.Integration.TestRepo, as: Repo
 
-  setup do
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
-
-    entries = [
+  setup_all do
+    Repo.insert_all("grouping", [
       %{foo: "a", bar: 1, baz: "c"},
       %{foo: "a", bar: 1, baz: "d"},
       %{foo: "a", bar: 2, baz: "c"},
       %{foo: "b", bar: 2, baz: "d"},
       %{foo: "b", bar: 3, baz: "c"},
-    ]
+    ])
 
-    Repo.insert_all("grouping", entries)
+    on_exit fn ->
+      Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    end
 
     :ok
   end

--- a/test/statistics_test.exs
+++ b/test/statistics_test.exs
@@ -3,10 +3,8 @@ defmodule Ecto.OLAP.StatisticsTest do
 
   alias Ecto.Integration.TestRepo, as: Repo
 
-  setup do
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
-
-    entries = [
+  setup_all do
+    Repo.insert_all("stats_agg", [
       %{year: 2000, divorce_rate: 5.0, marg_cons: 8.2},
       %{year: 2001, divorce_rate: 4.7, marg_cons: 7.0},
       %{year: 2002, divorce_rate: 4.6, marg_cons: 6.5},
@@ -17,9 +15,11 @@ defmodule Ecto.OLAP.StatisticsTest do
       %{year: 2007, divorce_rate: 4.2, marg_cons: 4.5},
       %{year: 2008, divorce_rate: 4.2, marg_cons: 4.2},
       %{year: 2009, divorce_rate: 4.2, marg_cons: 3.7},
-    ]
+    ])
 
-    Repo.insert_all("stats_agg", entries)
+    on_exit fn ->
+      Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    end
 
     :ok
   end


### PR DESCRIPTION
Use `Repo.one/1` instead of `Repo.all/1` so doctests do not need to
compare lists but values themselves.

Also setup tables only once before all tests in file to speedup testing.